### PR TITLE
Fix double scroll

### DIFF
--- a/autocomplete.js
+++ b/autocomplete.js
@@ -13,7 +13,6 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-labs-autocomplete">
 		<style>
 			#d2l-labs-autocomplete-list {
 				margin: 0;
-				max-height: 10rem;
 				padding: 0;
 			}
 
@@ -49,6 +48,7 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-labs-autocomplete">
 			</div>
 			<d2l-dropdown-content
 				id="d2l-labs-autocomplete-dropdown-content"
+				max-height="[[_maxHeight]]"
 				min-width="[[_minWidth]]"
 				no-auto-focus="[[selectFirst]]"
 				no-padding=""
@@ -139,6 +139,12 @@ class Autocomplete extends PolymerElement {
 			_keyCodes: {
 				type: Object,
 				value: { UP: 38, DOWN: 40, ENTER: 13, ESCAPE: 27, HOME: 36, END: 35 }
+			},
+			/**
+			 * Used to set max height of the dropdown
+			 */
+			_maxHeight: {
+				type: Number,
 			},
 			/**
 			 * Used to set min width of the dropdown

--- a/autocomplete.js
+++ b/autocomplete.js
@@ -14,7 +14,6 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-labs-autocomplete">
 			#d2l-labs-autocomplete-list {
 				margin: 0;
 				max-height: 10rem;
-				overflow-y: scroll;
 				padding: 0;
 			}
 


### PR DESCRIPTION
Remove scrolling on `<ul>` since d2l-dropdown-content supports scrolling the entire contents of the container. 

Also added support for setting max height on dropdown as a property instead of via max-height style on `<ul>` (which seems to break the content container scrolling in some cases).