### PR TITLE
Make max-height public property in autocomplete, allow setting on autocomplete-input-text

### DIFF
--- a/autocomplete-input-text.js
+++ b/autocomplete-input-text.js
@@ -17,6 +17,7 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-labs-autocomplete-input-tex
 			data="[[data]]"
 			dropdown-label="[[dropdownLabel]]"
 			id="[[_prefix('d2l-labs-autocomplete')]]"
+			max-height="[[maxHeight]]"
 			min-length="[[minLength]]"
 			on-d2l-labs-autocomplete-suggestion-selected="_handleSuggestionSelected"
 			remote-source="[[remoteSource]]"
@@ -65,6 +66,9 @@ class AutocompleteInputText extends PolymerElement {
 			dropdownLabel: {
 				type: String,
 				value: null,
+			},
+			maxHeight: {
+				type: Number,
 			},
 			minLength: {
 				type: String,

--- a/autocomplete.js
+++ b/autocomplete.js
@@ -48,7 +48,7 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-labs-autocomplete">
 			</div>
 			<d2l-dropdown-content
 				id="d2l-labs-autocomplete-dropdown-content"
-				max-height="[[_maxHeight]]"
+				max-height="[[maxHeight]]"
 				min-width="[[_minWidth]]"
 				no-auto-focus="[[selectFirst]]"
 				no-padding=""
@@ -141,12 +141,6 @@ class Autocomplete extends PolymerElement {
 				value: { UP: 38, DOWN: 40, ENTER: 13, ESCAPE: 27, HOME: 36, END: 35 }
 			},
 			/**
-			 * Used to set max height of the dropdown
-			 */
-			_maxHeight: {
-				type: Number,
-			},
-			/**
 			 * Used to set min width of the dropdown
 			 */
 			_minWidth: {
@@ -179,6 +173,12 @@ class Autocomplete extends PolymerElement {
 			*/
 			filterFn: {
 				type: Function,
+			},
+			/**
+			* Maximum height of the dropdown
+			*/
+			maxHeight: {
+				type: Number
 			},
 			/**
 			* Minimum required length of query before searching


### PR DESCRIPTION
Messed some stuff up in previous PR